### PR TITLE
Make whole session item clickable to trigger handlePlay event.

### DIFF
--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -6,17 +6,19 @@ const Item = ({
 }) => (
   <Fragment>
     <li className={`mdc-list-item ${locked ? 'mdc-list-item--disabled' : ''}`}>
-      {locked
-        ? <span className="mdc-list-item__graphic material-icons">lock</span>
-        : <span className="mdc-list-item__graphic">{index}</span>
-        }
-      <span className="mdc-list-item__text">
-        <span className="mdc-list-item__primary-text">{title}</span>
-        <span className="mdc-list-item__secondary-text">{duration}</span>
-      </span>
-      {handlePlay
-          && <button type="button" className="mdc-list-item__meta material-icons" onClick={handlePlay}>play_circle_filled</button>
-        }
+      <button className="clickable-item" type="button" onClick={handlePlay}>
+        {locked
+          ? <span className="mdc-list-item__graphic material-icons">lock</span>
+          : <span className="mdc-list-item__graphic">{index}</span>
+          }
+        <span className="mdc-list-item__text">
+          <span className="mdc-list-item__primary-text">{title}</span>
+          <span className="mdc-list-item__secondary-text">{duration}</span>
+        </span>
+        {handlePlay
+            && <span className="mdc-list-item__meta material-icons">play_circle_filled</span>
+          }
+      </button>
     </li>
     <li role="separator" className="mdc-list-divider mdc-list-divider--padded" />
   </Fragment>

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -5,20 +5,25 @@ const Item = ({
   index, title, duration, locked, handlePlay,
 }) => (
   <Fragment>
-    <li className={`mdc-list-item ${locked ? 'mdc-list-item--disabled' : ''}`}>
-      <button className="clickable-item" type="button" onClick={handlePlay}>
-        {locked
-          ? <span className="mdc-list-item__graphic material-icons">lock</span>
-          : <span className="mdc-list-item__graphic">{index}</span>
-          }
-        <span className="mdc-list-item__text">
-          <span className="mdc-list-item__primary-text">{title}</span>
-          <span className="mdc-list-item__secondary-text">{duration}</span>
-        </span>
-        {handlePlay
-            && <span className="mdc-list-item__meta material-icons">play_circle_filled</span>
-          }
-      </button>
+    <li
+      className={`mdc-list-item ${locked ? 'mdc-list-item--disabled' : ''}`}
+      tabIndex={index === 1 ? '0' : undefined} // set tabIndex to 0 only on first li, as per MDC web docs on lists
+      onKeyDown={handlePlay}
+      onClick={handlePlay}
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
+      role="button"
+    >
+      {locked
+        ? <span className="mdc-list-item__graphic material-icons">lock</span>
+        : <span className="mdc-list-item__graphic">{index}</span>
+        }
+      <span className="mdc-list-item__text">
+        <span className="mdc-list-item__primary-text">{title}</span>
+        <span className="mdc-list-item__secondary-text">{duration}</span>
+      </span>
+      {handlePlay
+          && <span className="mdc-list-item__meta material-icons">play_circle_filled</span>
+        }
     </li>
     <li role="separator" className="mdc-list-divider mdc-list-divider--padded" />
   </Fragment>

--- a/src/index.scss
+++ b/src/index.scss
@@ -13,10 +13,6 @@ body {
   margin: 0;
 }
 
-button {
-  all: unset; // To remove default styling of buttons
-}
-
 a {
   text-decoration: none;
 }
@@ -127,6 +123,24 @@ a {
 
 .mdc-list-item__graphic.material-icons {
   font-size: 18px;
+}
+
+.clickable-item {
+  font: inherit;
+  color: inherit;
+  border: none;
+  background-color: transparent;
+  display:inherit;
+  padding: 0 16px;
+  align-items: center;
+  justify-content: flex-start;
+  overflow: hidden;
+  width: 100%;
+  text-align: left;
+}
+
+#session-list > .mdc-list-item {
+  padding: 0px;
 }
 
 //library page

--- a/src/index.scss
+++ b/src/index.scss
@@ -125,24 +125,6 @@ a {
   font-size: 18px;
 }
 
-.clickable-item {
-  font: inherit;
-  color: inherit;
-  border: none;
-  background-color: transparent;
-  display:inherit;
-  padding: 0 16px;
-  align-items: center;
-  justify-content: flex-start;
-  overflow: hidden;
-  width: 100%;
-  text-align: left;
-}
-
-#session-list > .mdc-list-item {
-  padding: 0px;
-}
-
 //library page
 .courses {
   list-style: none;

--- a/src/pages/CoursePage.js
+++ b/src/pages/CoursePage.js
@@ -1,22 +1,32 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { MDCList } from '@material/list';
 
 import Item from '../components/Item';
 import AudioPlayer from '../components/AudioPlayer';
 import BackButton from '../components/BackButton';
 import { setTrack } from '../actions';
 
+
 const CoursePage = ({
   // eslint-disable-next-line no-shadow
   course, subscription, currentTrack, setTrack,
 }) => {
+  useEffect(() => {
+    // eslint-disable-next-line no-unused-vars
+    const list = new MDCList(document.querySelector('.mdc-list'));
+  });
+
   let sessionCards;
 
   // Set and play the track
   const handlePlay = (sessionId, e) => {
     e.preventDefault();
-    setTrack(course._id, sessionId);
+    // On click, Space key or Enter key
+    if (e.type === 'click' || e.keyCode === 32 || e.keyCode === 13) {
+      setTrack(course._id, sessionId);
+    }
   };
 
   // When course has loaded in
@@ -40,7 +50,7 @@ const CoursePage = ({
         <h1 className="mdc-typography--headline5 title">Basics</h1>
         <p className="mdc-typography--subtitle2 subtitle">Live happier and healthier by learning the fundamentals of meditation and mindfulness.</p>
       </div>
-      <ul id="session-list" className="mdc-list mdc-list--two-line mdc-list--avatar-list mdc-list--dense">
+      <ul className="mdc-list mdc-list--two-line mdc-list--avatar-list mdc-list--dense">
         {sessionCards}
       </ul>
       {currentTrack && (<AudioPlayer />)}

--- a/src/pages/CoursePage.js
+++ b/src/pages/CoursePage.js
@@ -40,7 +40,7 @@ const CoursePage = ({
         <h1 className="mdc-typography--headline5 title">Basics</h1>
         <p className="mdc-typography--subtitle2 subtitle">Live happier and healthier by learning the fundamentals of meditation and mindfulness.</p>
       </div>
-      <ul className="mdc-list mdc-list--two-line mdc-list--avatar-list mdc-list--dense">
+      <ul id="session-list" className="mdc-list mdc-list--two-line mdc-list--avatar-list mdc-list--dense">
         {sessionCards}
       </ul>
       {currentTrack && (<AudioPlayer />)}


### PR DESCRIPTION
Make whole items in CoursePage trigger handlePlay on click, instead of only the play button.

This was achieved by wrapping the inner elements of the li with a button element and tweaking the styling to keep the same appearance.